### PR TITLE
Fix bug in mergeObject function. It failed to properly merge object w…

### DIFF
--- a/lib/merger.js
+++ b/lib/merger.js
@@ -166,7 +166,7 @@ function mergeObjects(source, target, opts) {
     let item = source[property]
 
     // Is this an object? Should we perform recursive merge?
-    if (opts.recurse && item instanceof Object) {
+    if (opts.recurse && item instanceof Object && !(item instanceof Function)) {
       // If the item on the source is object, we must have such object on the target as well
       // So we either reuse any such existing "receiving" object or we create a new one
       const receiver = target[property] instanceof Object ? target[property]


### PR DESCRIPTION
…ith item of type 'Function'.

the fix was to prevent a recursive call to 'doMerge' if item is of type Function. Apperantly Functions are both of type Object and Function at the same time!